### PR TITLE
Replace java:8 by eclipse-temurin:8, so this works with recent docker installations

### DIFF
--- a/adminserver/src/main/docker/Dockerfile
+++ b/adminserver/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM eclipse-temurin:8
 VOLUME /tmp
 ADD *.jar /app.jar
 ADD wait-for-it.sh /wait-for-it.sh

--- a/api-gateway/src/main/docker/Dockerfile
+++ b/api-gateway/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM eclipse-temurin:8
 VOLUME /tmp
 ADD *.jar /app.jar
 ADD wait-for-it.sh /wait-for-it.sh

--- a/authserver/src/main/docker/Dockerfile
+++ b/authserver/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM eclipse-temurin:8
 VOLUME /tmp
 ADD *.jar /app.jar
 ADD wait-for-it.sh /wait-for-it.sh

--- a/circuit-breaker/src/main/docker/Dockerfile
+++ b/circuit-breaker/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM eclipse-temurin:8
 VOLUME /tmp
 ADD *.jar /app.jar
 ADD wait-for-it.sh /wait-for-it.sh

--- a/command-side-blog-service/src/main/docker/Dockerfile
+++ b/command-side-blog-service/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM eclipse-temurin:8
 VOLUME /tmp
 ADD *.jar /app.jar
 ADD wait-for-it.sh /wait-for-it.sh

--- a/command-side-project-service/src/main/docker/Dockerfile
+++ b/command-side-project-service/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM eclipse-temurin:8
 VOLUME /tmp
 ADD *.jar /app.jar
 ADD wait-for-it.sh /wait-for-it.sh

--- a/configserver/src/main/docker/Dockerfile
+++ b/configserver/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM eclipse-temurin:8
 VOLUME /tmp
 ADD *.jar /app.jar
 RUN bash -c 'touch /app.jar'

--- a/monolithic/src/main/docker/Dockerfile
+++ b/monolithic/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM eclipse-temurin:8
 VOLUME /tmp
 ADD *.jar /app.jar
 RUN bash -c 'touch /app.jar'

--- a/query-side-blog-service/src/main/docker/Dockerfile
+++ b/query-side-blog-service/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM eclipse-temurin:8
 VOLUME /tmp
 ADD *.jar /app.jar
 ADD wait-for-it.sh /wait-for-it.sh

--- a/query-side-project-service/src/main/docker/Dockerfile
+++ b/query-side-project-service/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM eclipse-temurin:8
 VOLUME /tmp
 ADD *.jar /app.jar
 ADD wait-for-it.sh /wait-for-it.sh

--- a/registry/src/main/docker/Dockerfile
+++ b/registry/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM eclipse-temurin:8
 VOLUME /tmp
 ADD *.jar /app.jar
 ADD wait-for-it.sh /wait-for-it.sh


### PR DESCRIPTION
`java:8` is not longer a Docker image, instead, the concrete JVM (e.g., `eclipse-temurin:8`) should be specified. Using `java:8` results in errors like

> [ERROR] Failed to execute goal com.spotify:docker-maven-plugin:0.4.9:build (default-cli) on project query-side-blog-service: Exception caught: manifest for java:8 not found: manifest unknown: manifest unknown -> [Help 1]

I've replaced all `FROM` specification in the dockerfiles, so after this is fixed, the project should build again with recent docker versions. 

This can be done using `for file in $(find . -name "Dockerfile"); do sed -i "s/java:8/eclipse-temurin:8/g" $file; done` (or potentially another image, like the slim version of temurin). 